### PR TITLE
cleaner API, more efficient parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,13 @@ if sse.error then
   --handle error stuff
 end
 ```
+
+## sse.connect_timeout
+
+max time to connect to SSE server, in milliseconds. Default is 5000
+
+## sse.readline_timeout
+
+max time to wait until retrying to read a line from the sse socket, in milliseconds. Should be really large for best efficiency. 
+
+Default is 10 days.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ server {
 
 # API
 
-## SSE.new(url, headers)
+## `SSE.new(url, headers)`
 
 ```lua 
   local SSE = require "resty.sse"
@@ -58,7 +58,7 @@ server {
 ```
 return new `sse` object, ready to connect to `url` with optional `headers` table
 
-## sse:connect()
+## `sse:connect()`
 ```lua
   local res, err = sse_client:connect()
 ```
@@ -66,15 +66,15 @@ attempt to connect to SSE server. return `true` on success, `nil, error` on fail
 
 It is _not necessary_ to call this function explicitly, the `sse` client will attempt to `connect()` as needed.
 
-## sse:close()
+## `sse:close()`
 
 close the connection
 
-## sse.error
+## `sse.error`
 
 last error string from running the `sse` client, or nil when running without errors
 
-## sse:events()
+## `sse:events()`
 
 `for`-loop iterator to receive SSE events:
 
@@ -90,11 +90,11 @@ if sse.error then
 end
 ```
 
-## sse.connect_timeout
+## `sse.connect_timeout`
 
 max time to connect to SSE server, in milliseconds. Default is 5000
 
-## sse.readline_timeout
+## `sse.readline_timeout`
 
 max time to wait until retrying to read a line from the sse socket, in milliseconds. Should be really large for best efficiency. 
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@ Lua Server Side Events client cosocket driver for [OpenResty](http://openresty.o
 
 This library is still under active development and is considered production ready.
 
-# API
-
-* [new](#name)
-* [connect](#connect)
-* [set_timeout](#set_timeout)
-* [set_keepalive](#set_keepalive)
-* [get_reused_times](#get_reused_times)
-* [close](#close)
-* [request](#request)
-* [request_uri](#request_uri)
-* [sse_loop](#sse_loop)
-
 ## Synopsis
 
 ``` lua
@@ -60,14 +48,20 @@ server {
 }
 ```
 
-# SSE
+# API
 
 ## SSE.new(url, headers)
 
+```lua 
+  local SSE = require "resty.sse"
+  local sse_client = SSE.new("http://sse_server.example/sse_url")
+```
 return new `sse` object, ready to connect to `url` with optional `headers` table
 
 ## sse:connect()
-
+```lua
+  local res, err = sse_client:connect()
+```
 attempt to connect to SSE server. return `true` on success, `nil, error` on failure.
 
 It is _not necessary_ to call this function explicitly, the `sse` client will attempt to `connect()` as needed.

--- a/lib/resty/sse.lua
+++ b/lib/resty/sse.lua
@@ -93,7 +93,7 @@ function SSE:close()
   self.http_client = nil
 end
 
--- for event in sse:events do
+-- for event in sse:events() do
 --   ...
 --end
 function SSE:events()

--- a/lib/resty/sse.lua
+++ b/lib/resty/sse.lua
@@ -24,6 +24,8 @@ function SSE:connect()
     return nil, "already connected"
   end
   
+  self.error = nil
+  
   local httpc, err = http.new()
   if not httpc then
     self.error = err

--- a/lib/resty/sse.lua
+++ b/lib/resty/sse.lua
@@ -16,7 +16,7 @@ local SSE_module = {
 local SSE = {}
 SSE_metatable = {__index = SSE}
 
-SSE.connect_timeout = 5000 --default connect timeout is 5 minutes
+SSE.connect_timeout = 5000 --default connect timeout is 5 seconds
 SSE.readline_timeout = 1000*60*60*24*10 -- 10 days in msec
 
 function SSE:connect()

--- a/lib/resty/sse.lua
+++ b/lib/resty/sse.lua
@@ -1,245 +1,152 @@
 local http = require "resty.http" -- https://github.com/pintsized/lua-resty-http
-local cjson = require "cjson"
 
--- variable caching (https://www.cryptobells.com/properly-scoping-lua-nginx-modules-ngx-ctx/)
-local str_find   = string.find
-local str_sub    = string.sub
-local str_gfind  = string.gfind or string.gmatch -- http://lua-users.org/lists/lua-l/2013-04/msg00117.html
-local tbl_insert = table.insert
+local unpack = table.unpack or unpack
 
--- internal/private string helpers
-local function str_trim(s) -- remove trailing and leading whitespace from string.
-  -- from PiL2 20.4
-  return (s:gsub("^%s*(.-)%s*$", "%1"))
-end
-
-local function str_ltrim(s) -- remove leading whitespace from string.
-  return (s:gsub("^%s*", ""))
-end
-
-local function str_rtrim(s) -- remove trailing whitespace from string.
-  local n = #s
-  while n > 0 and s:find("^%s", n) do n = n - 1 end
-  return s:sub(1, n)
-end
-
-function str_split(str, delim)
-    local result    = {}
-    local pat       = "(.-)"..delim.."()"
-    local lastPos   = 1
-
-    for part, pos in str_gfind(str, pat) do
-        tbl_insert(result, part)
-        lastPos = pos
-    end -- for
-    tbl_insert(result, str_sub(str, lastPos))
-    return result
-end -- split
-
-local DEFAULT_CALLBACKS = {
-    error = function(chunk, err)
-        ngx.log(ngx.ERR, cjson.encode({chunk = chunk, error = err}))
-        ngx.flush(false)
-    end, -- function
-    event = function(strut)
-        ngx.say(cjson.encode({strut = strut}))
-        ngx.flush(true)
-    end -- function
+local SSE_metatable
+local SSE_module = {
+  _VERSION = '0.2.0',
+  new = function(url, headers)
+    return setmetatable({
+      request_url = url,
+      request_headers = headers or {}
+    }, SSE_metatable)
+  end
 }
 
-local _M = {_VERSION = '0.1.1'}
-_M.__index = _M
+local SSE = {}
+SSE_metatable = {__index = SSE}
 
-function _M.new()
-    local httpc, err = http.new()
-    if not httpc then
-        return nil, err
+function SSE:connect()
+  if self.http_client then
+    return nil, "already connected"
+  end
+  
+  local httpc, err = http.new()
+  if not httpc then
+    self.error = err
+    return nil, err
+  end
+
+  local parsed_uri, err = httpc:parse_uri(self.request_url)
+  if not parsed_uri then
+    self.error = err
+    return nil, err
+  end
+
+  local _, host, port, path = unpack(parsed_uri)
+
+  local ok, err = httpc:connect(host, port)
+  if not ok then
+    self.error = err
+    return nil, err
+  end
+
+  local headers = self.request_headers
+  headers['Accept'] = "text/event-stream"
+  headers['Host'] = host
+  if headers['User-Agent'] == nil then
+    headers['User-Agent'] = "lua-resty-sse/" .. SSE_module._VERSION
+  end
+
+  local response, err = httpc:request({
+    method = "GET",
+    path = path,
+    headers = headers,
+  })
+
+  if not response then
+    self.error = err
+    return nil, err
+  end
+
+  -- check to make sure the status code that came back is the correct range
+  if response.status < 200 or response.status > 299 then
+    self.error = "bad response status code: " .. response.status
+    return nil, self.error
+  end
+  -- make sure we got the right content type back in the headers
+  local content_type = response.headers["Content-Type"]
+  if not content_type then
+    self.error = "Content-Type missing in response"
+    return nil, self.error
+  elseif not content_type:match("text/event%-stream") then
+    self.error = "Content Type not text/event-stream ("..content_type..")"
+    return nil, self.error
+  end
+
+  self.error = nil
+  self.http_client = httpc
+  return true
+end
+
+function SSE:close()
+  self.http_client:close()
+  self.http_client = nil
+end
+
+-- for event in sse:events do
+--   ...
+--end
+function SSE:events()
+  if not self.http_client then
+    self:connect()
+  end
+
+  if not self.http_client or self.error then
+    --we have no connection
+    return function() end
+  end
+
+  local evt_type, evt_id, evt_data = nil ,nil, {}
+
+  local line, err, partial
+  local socket = self.http_client.sock
+  local function readline()
+    line, err, partial = socket:receive("*l")
+    if not line then
+      if err == "timeout" then --we don't care about timeouts
+        return readline() --no stack overflow danger, tail recusion calls are optimized away
+      else
+        self.error = err
+      end
     end
-    local that = {httpc=httpc}
-    setmetatable(that, _M)
-    return that
-end -- new
+    -- pretty sure we don't care about partial reads. whole lines only plz
+    return line
+  end
 
-function _M.set_timeout(self, timeout)
-    return self.httpc:set_timeout(timeout)
-end -- set_timeout
+  self.error = nil
 
-function _M.set_keepalive(self, ...)
-    return self.httpc:set_keepalive(...)
-end -- set_keepalive
-
-function _M.get_reused_times(self, ...)
-    return self.httpc:get_reused_times(...)
-end -- get_reused_times
-
-function _M.close(self)
-    self.httpc:close()
-end -- close
-
-function _M.connect(self, ...)
-    self.read_before = false
-    return self.httpc:connect(...)
-end -- connect
-
-function _headers_format_request(headers)
-    if type(headers) ~= "table" then
-        headers = {}
-    end -- if
-
-    headers['Accept'] = "text/event-stream"
-
-    if headers['User-Agent'] == nil then
-        headers['User-Agent'] = "lua-resty-sse-v"
-    end -- if
-
-    return headers
-end -- headers_format_request
-
-function _M.request(self, params)
-    params["method"]  = "GET"
-    params["headers"] = _headers_format_request(params["headers"])
-
-    local res, err = self.httpc:request(params)
-    if err then
-        return nil, err
-    end -- if
-
-    self.res = res
-    return res, err
-end -- request
-
-function _M.request_uri(self, uri, params)
-    local parsed_uri, err = self.httpc:parse_uri(uri)
-    if not parsed_uri then
-        return nil, err
-    end
-
-    local scheme, host, port, path = unpack(parsed_uri)
-
-    local c, err = self:connect(host, port)
-    if not c then
-        return nil, err
-    end
-
-    params["path"]    = path
-    params["headers"] = _headers_format_request(params["headers"])
-    if params["headers"]["Host"] == nil then
-        params["headers"]["Host"] = host
-    end
-    return self:request(params)
-end -- request_uri
-
-local function _parse_sse(buffer)
-    local strut         = { event = nil, id = nil, data = {} }
-    local strut_started = false
-    local buffer_lines  = nil
-    local frame_break   = str_find(buffer, "\n\n") -- make sure we have at least one frame ini this
-    local err           = nil
-
-    if frame_break ~= nil then
-        buffer_lines = str_split(str_sub(buffer, 1, frame_break), "\n") -- get one frame from the buffer and split it into lines
-    else
-        return nil, buffer, nil
-    end -- if
-
-    for _, dat in pairs(buffer_lines) do
-        local s1, s2 = str_find(dat, ":") -- find where the cut point is
-
-        if s1 and s1 ~= 1 then
-            local field = str_sub(dat, 1, s1-1) -- returns "data " from data: hello world
-            local value = str_ltrim(str_sub(dat, s1+1)) -- returns "hello world" from data: hello world
-            -- note: make sure to trim leading whitespace
-
-            if field then strut_started = true end
-
-            -- for now not checking if the value is already been set
-            if     field == "event" then strut.event = value
-            elseif field == "id"    then strut.id = value
-            elseif field == "data"  then tbl_insert(strut.data, value)
-            end -- if
-        else
-            -- this is for comments
-        end -- if
-    end -- for
-
-    -- reply back with the rest of the buffer
-    buffer = str_sub(buffer, frame_break+2) -- +2 because we want to be on the other side of \n\n
-
-    if strut_started then
-        return strut, buffer, err
-    else
-        return nil, buffer, err
-    end
-end -- parse_sse
-
-function _M.headers_check_response(self)
-    local find_mime = nil
-
-    -- check to make sure the status code that came back is the coorect range
-    if self.res.status < 200 or self.res.status > 299 then
-        return nil, "Status Non-200 ("..self.res.status..")"
-    end -- if
-
-    -- make sure we got the right content type back in the headers
-    find_mime, _ = str_find(self.res.headers["Content-Type"], "text/event-stream",1,true)
-    if find_mime == nil then
-        return nil, "Content Type not text/event-stream ("..self.res.headers["Content-Type"]..")"
-    end
-
-    return true
-
-end -- headers_check_response
-
-function _M.sse_loop(self, event_cb, error_cb)
-    local reader    = nil
-    local parse_err = nil
-    local strut     = nil
-    local leave     = nil
-    local sock      = self.httpc.sock
-    local reader    = sock.receive
-
-    self.buffer = self.buffer or "" -- initialize buffer
-
-    if not event_cb then event_cb = DEFAULT_CALLBACKS.event end
-    if not error_cb then error_cb = DEFAULT_CALLBACKS.error end
-
-    repeat
-        local chunk, err, pchunk= reader(sock,"*l")
-        if err and err ~= "timeout" then -- if we have an error show it and and then hop out
-            chunks = cjson.encode({chunk, pchunk})
-            error_cb(chunks, err)
-            break -- break out of the code
-        end -- if
-
-        if chunk then -- this means we got a full line from the system
-            self.buffer = self.buffer .. chunk .. "\n" -- update the buffer with the new chunk
-        end -- if
-
-        if pchunk then -- this means we did not get a full line
-            self.buffer = self.buffer .. pchunk
-        end -- if
-
-        if not chunk and not pchunk then -- because we have nothing new to parse
-            break
+  --iterator for for-loop
+  return function()
+    while readline() do
+      if #line > 0 then
+        local lbl, val = line:match("(%w*): (.*)")
+        if lbl     == "data" then
+          table.insert(evt_data, val)
+        elseif lbl == "id" then
+          evt_id = val
+        elseif lbl == "event" then
+          evt_type = val
         end
+        --otherwise it's an invalid line or a comment. we can ignore those
+      else
+        --event end
+        if #evt_data > 0 then
+          --build event data
+          local event = {
+            data = table.concat(evt_data, "\n"),
+            id = evt_id,
+            event = evt_type or "message"
+          }
+          --reset buffers
+          evt_data, evt_id, evt_type = {}, nil, nil
+          return event
+        else
+          -- extra newline? whatever, ignore it, even though that's kinda invalid
+        end
+      end
+    end
+  end
+end
 
-        while self.buffer:len() > 0 do
-            -- parse the data that is in the buffer
-            strut, self.buffer, parse_err = _parse_sse(self.buffer)
-            if strut ~= nil and strut ~= false then
-                leave = event_cb(strut)
-            end -- if
-
-            -- lets see if its time to blow this popsical joint
-            if strut == nil or strut == false or leave == true or parse_err ~= nil then
-                if parse_err ~= nil then
-                    -- speak about the parse error
-                end -- if
-
-                break
-            end -- if
-        end -- while
-    until not chunk or not pchunk -- because we have nothing to do
-end -- sse_loop
-
-return _M
+return SSE_module

--- a/lua-resty-sse-0.2.0-1.rockspec
+++ b/lua-resty-sse-0.2.0-1.rockspec
@@ -7,7 +7,7 @@ source = {
 description = {
    detailed = "Lua Server Side Events client cosocket driver for [OpenResty](http://openresty.org/) / [ngx_lua](https://github.com/openresty/lua-nginx-module).",
    homepage = "https://github.com/wojons/lua-resty-sse",
-   license = "*** please specify a license ***",
+   license = "MIT",
 }
 dependencies = {
    "lua >= 5.1",

--- a/lua-resty-sse-0.2.0-1.rockspec
+++ b/lua-resty-sse-0.2.0-1.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-sse"
-version = "0.1.1-1"
+version = "0.2.0-1"
 source = {
    url = "git://github.com/wojons/lua-resty-sse.git",
-   tag = "v0.1.1",
+   tag = "v0.2.0",
 }
 description = {
    detailed = "Lua Server Side Events client cosocket driver for [OpenResty](http://openresty.org/) / [ngx_lua](https://github.com/openresty/lua-nginx-module).",


### PR DESCRIPTION
```lua
      local SSE = require "resty.sse"

      local headers = {
        ["X-Some-Header-Field"] = "foobar"
      }
      local sse = SSE.new("http://some-pub-sub-server.com/subscriber", headers) --header table is optional
      --never fails, always returns new sse 'object'

      --explicitly calling :connect() is optional. SSE will connect as needed
      local ok, err = sse:connect()
      if not ok then 
        ngx.say("SSE failed: ", err)
        return
      end

      --message processing loop 
      for evt in sse:events() do
        ngx.say("SSE id:", evt.id or "")
        ngx.say("SSE event-type:", evt.type)
        ngx.say("SSE data:", evt.data)
      end
      
      --why did we exit the message processing loop?
      if sse.error then
        ngx.say("SSE error:", sse.error)
      end
```

don't forget to tag the merge commit 'v0.2.0' for luarocks